### PR TITLE
[Bug-Fix] - Authentication Bearer Token Not Refreshing

### DIFF
--- a/addons/supabase/Auth/auth.gd
+++ b/addons/supabase/Auth/auth.gd
@@ -280,6 +280,7 @@ func _on_task_completed(task : AuthTask) -> void:
 		if task.user != null:
 			client = task.user
 			_auth = client.access_token
+			_bearer = ["Authorization: Bearer %s"]
 			_bearer[0] = _bearer[0] % _auth
 			_expires_in = client.expires_in
 			match task._code:


### PR DESCRIPTION
Fixed Bug that prevented user from being re-authenticated. The bearer token's format string got overwritten and was never reset. 

This caused an error pictured below:
![Image](https://user-images.githubusercontent.com/49920384/193437061-ea97e379-4cd7-4e3c-89b8-f555d4e6f0be.png)