### PR TITLE
fix case on "FILTERS.IN"

### DIFF
--- a/addons/supabase/Database/query.gd
+++ b/addons/supabase/Database/query.gd
@@ -168,7 +168,7 @@ func match_filter(filter : int) -> String:
 		Filters.EQUAL: filter_str = "eq"
 		Filters.FTS: filter_str = "fts"
 		Filters.ILIKE: filter_str = "ilike"
-		Filters.IN: filter_str = "in"
+		Filters.IN: filter_str = "In"
 		Filters.IS: filter_str = "Is"
 		Filters.GREATER_THAN: filter_str = "gt"
 		Filters.GREATER_THAN_OR_EQUAL: filter_str = "gte"

--- a/addons/supabase/Database/query.gd
+++ b/addons/supabase/Database/query.gd
@@ -87,7 +87,7 @@ func build_query() -> String:
 				"select", "order":
 					if query_struct[key].is_empty(): continue
 					query += (key + "=" + ",".join(PackedStringArray(query_struct[key])))
-				"eq", "neq", "lt", "gt", "lte", "gte", "like", "ilike", "Is", "in", "fts", "plfts", "phfts", "wfts":
+				"eq", "neq", "lt", "gt", "lte", "gte", "like", "ilike", "Is", "In", "fts", "plfts", "phfts", "wfts":
 					query += "&".join(PackedStringArray(query_struct[key]))
 				"Or":
 					query += "or=(%s)"%[",".join(query_struct[key])]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently when using the SupabaseQuery.In function, it resolves to "in" where the concerned object has key "In". This throws an error.

## What is the new behavior?

SupabaseQuery.In works properly
