### PR TITLE
Fix Rpc calls erroring on response

### DIFF
--- a/addons/supabase/Database/database_task.gd
+++ b/addons/supabase/Database/database_task.gd
@@ -11,7 +11,9 @@ func match_code(code : int) -> int:
 		_: return HTTPClient.METHOD_POST
 
 func _on_task_completed(result : int, response_code : int, headers : PackedStringArray, body : PackedByteArray, handler: HTTPRequest) -> void:
-	var result_body: Variant = JSON.parse_string(body.get_string_from_utf8())
+	var result_body: Variant = null
+	if body:
+		result_body = JSON.parse_string(body.get_string_from_utf8())
 	if response_code < 300:
 		complete(result_body)
 	else:


### PR DESCRIPTION
Rpc calls can respond with empty body, therefore old logic errors out due to not being able to parse json from null.

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

database.Rpc calls end up throwing an error because they try to parse the json from null

## What is the new behavior?

Errors are not thrown and body is returned as null if it's nonexistent

